### PR TITLE
Full page chart and removed chart name from js

### DIFF
--- a/iplotter/iplotter.py
+++ b/iplotter/iplotter.py
@@ -111,10 +111,10 @@ class PlotlyPlotter(IPlotter):
         '''
 
         self.template = '''
-            <div id={{name}}></div>
+            <div id="chartElement" style="width: 100%; height: 100%"></div>
             <script>
-                var {{name}} = document.getElementById('{{name}}');
-                Plotly.plot({{name}}, {{data}}, {{layout}});
+                var chartElement = document.getElementById('chartElement');
+                Plotly.plot(chartElement, {{data}}, {{layout}});
             </script>
         '''
 


### PR DESCRIPTION
This lets you see the chart as the entire web page. Also, I got a syntax error when giving a chart a name that has spaces in it. If you need the var name to be unique then we can either:
- Escape the name
- Use a scope to prevent leaking/overwriting things in the js name.
